### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ nextversion
 .. image:: https://travis-ci.org/laysakura/nextversion.png?branch=master
    :target: https://travis-ci.org/laysakura/nextversion
 
-.. image:: https://pypip.in/v/nextversion/badge.png
+.. image:: https://img.shields.io/pypi/v/nextversion.svg
     :target: https://pypi.python.org/pypi/nextversion
     :alt: Latest PyPI version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nextversion))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nextversion`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.